### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -6,6 +6,10 @@ name: OSSAR
 on:
   push:
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   OSSAR-Scan:
     # OSSAR runs on windows-latest.


### PR DESCRIPTION
Potential fix for [https://github.com/ngraziano/shellies-coap2mqtt/security/code-scanning/1](https://github.com/ngraziano/shellies-coap2mqtt/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ossar-analysis.yml` at the workflow root (recommended here since there is one job).  
Use least privilege required by current steps:

- `contents: read` for checkout.
- `security-events: write` for SARIF upload (`upload-sarif` needs this).

Place the block after `on:` (or before `jobs:`) so it applies to all jobs unless overridden. This does not change workflow behavior beyond tightening token scope and making permissions explicit/documented.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
